### PR TITLE
llvm balls

### DIFF
--- a/balls.ll
+++ b/balls.ll
@@ -1,0 +1,18 @@
+
+@.str = private unnamed_addr constant [7 x i8] c"balls\0A\00"
+
+; External declaration of the puts function
+declare i32 @puts(i8* nocapture) nounwind
+
+; Definition of main function
+define i32 @main() { ; i32()*
+    %cast210 = getelementptr [7 x i8],[7 x i8]* @.str, i64 0, i64 0
+
+    ; Call puts function to write out the string to stdout.
+    call i32 @puts(i8* %cast210)
+    ret i32 0
+}
+
+; Named metadata
+!0 = !{i32 42, null, !"string"}
+!foo = !{!0}

--- a/llvm_generated_balls.s
+++ b/llvm_generated_balls.s
@@ -1,0 +1,22 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.macosx_version_min 10, 17
+	.globl	_main                   ## -- Begin function main
+	.p2align	4, 0x90
+_main:                                  ## @main
+	.cfi_startproc
+## %bb.0:
+	pushq	%rax
+	.cfi_def_cfa_offset 16
+	leaq	L_.str(%rip), %rdi
+	callq	_puts
+	xorl	%eax, %eax
+	popq	%rcx
+	retq
+	.cfi_endproc
+                                        ## -- End function
+	.section	__TEXT,__cstring,cstring_literals
+L_.str:                                 ## @.str
+	.asciz	"balls\n"
+
+
+.subsections_via_symbols


### PR DESCRIPTION
```shell
$ llc balls.ll
```
Produces `balls.s`

```shell
$ lli balls.ll
```
Interprets instead of compile